### PR TITLE
[FEAT] 회원가입 4단계 UI 구현

### DIFF
--- a/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep4Screen.kt
+++ b/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep4Screen.kt
@@ -1,0 +1,229 @@
+package com.and.presentation.screen.register
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.and.presentation.R
+import com.and.presentation.component.HintErrorTextField
+import com.and.presentation.component.button.ConditionalNextButton
+import com.and.presentation.ui.DefaultWhiteTheme
+import com.and.presentation.ui.Primary0
+import com.and.presentation.util.NICKNAME_MAX_LENGTH
+import com.and.presentation.util.nicknameValidation
+import com.and.presentation.util.type.Gender
+
+@Composable
+fun RegisterStep4Screen(
+    onNext: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var userNickname by remember { mutableStateOf("") }
+    val isNicknameValid = userNickname.nicknameValidation()
+    val isBirthYearSelected by remember { mutableStateOf(false) }
+    var userGender by remember { mutableStateOf<Gender?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 14.dp)
+        ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = stringResource(R.string.register_nickname_title),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(48.dp))
+            HintErrorTextField(
+                maxLength = NICKNAME_MAX_LENGTH,
+                value = userNickname,
+                onValueChange = { userNickname = it },
+                valueTitle = stringResource(id = R.string.nickname),
+                valueHint = stringResource(id = R.string.register_nickname_placeholder),
+                isError = userNickname.isNotBlank() && !isNicknameValid,
+                modifier = Modifier
+                    .padding(top = 12.dp)
+            )
+            if (userNickname.isNotBlank() && !isNicknameValid) {
+                Text(
+                    text = stringResource(R.string.register_nickname_placeholder),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(top = 6.dp, start = 6.dp),
+                    color = Color.Red
+                )
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            RegisterBirthYear(
+                onClick = {
+
+                }
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            RegisterGenderRadioGroup(
+                userGender = userGender,
+                onClick = { userGender = it }
+            )
+        }
+
+        ConditionalNextButton(
+            enabled = isNicknameValid && isBirthYearSelected && (userGender != null),
+            onClick = onNext,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Composable
+fun RegisterBirthYear(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        Text(
+            text = stringResource(R.string.birth_year),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 6.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = onClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .border(
+                    width = 1.dp,
+                    color = Color.Gray,
+                    shape = RoundedCornerShape(12.dp)
+                ),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.White
+            ),
+            contentPadding = PaddingValues(start = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.select),
+                fontSize = 16.sp,
+                color = Color.Gray,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = stringResource(R.string.register_birth_year_desc),
+            fontSize = 12.sp,
+            color = Color.Gray,
+            modifier = Modifier.padding(start = 6.dp)
+        )
+    }
+}
+
+@Composable
+fun RegisterGenderRadioGroup(
+    userGender: Gender?,
+    onClick: (Gender) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        Text(
+            text = stringResource(R.string.gender),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 6.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+        ) {
+            Button(
+                onClick = { onClick(Gender.MALE) },
+                modifier = Modifier
+                    .padding(end = 4.dp)
+                    .height(56.dp)
+                    .weight(1f),
+                shape = RoundedCornerShape(15.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (userGender == Gender.MALE) Primary0
+                    else Color(0xFFD9D9D9),
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.gender_male),
+                    fontSize = 16.sp
+                )
+            }
+            Button(
+                onClick = { onClick(Gender.FEMALE) },
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .height(56.dp)
+                    .weight(1f),
+                shape = RoundedCornerShape(15.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (userGender == Gender.FEMALE) Primary0
+                    else Color(0xFFD9D9D9),
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.gender_female),
+                    fontSize = 16.sp
+                )
+            }
+        }
+    }
+}
+
+@Preview(
+    name = "RegisterStep4Screen Preview",
+    showBackground = true
+)
+@Composable
+fun RegisterStep4ScreenPreview() {
+    DefaultWhiteTheme {
+        RegisterStep4Screen(
+            onNext = {
+
+            },
+            onBack = {
+
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/and/presentation/util/Constants.kt
+++ b/presentation/src/main/java/com/and/presentation/util/Constants.kt
@@ -2,5 +2,6 @@ package com.and.presentation.util
 
 const val ID_MIN_LENGTH = 6
 const val ID_MAX_LENGTH = 12
-
 const val PASSWORD_MIN_LENGTH = 8
+const val NICKNAME_MIN_LENGTH = 1
+const val NICKNAME_MAX_LENGTH = 12

--- a/presentation/src/main/java/com/and/presentation/util/type/Gender.kt
+++ b/presentation/src/main/java/com/and/presentation/util/type/Gender.kt
@@ -1,0 +1,6 @@
+package com.and.presentation.util.type
+
+enum class Gender(val gender: String) {
+    MALE("남자"),
+    FEMALE("여자")
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -2,8 +2,15 @@
     <string name="app_name">NewDok</string>
 
     <string name="next">다음</string>
+    <string name="select">선택</string>
     <string name="id">아이디</string>
     <string name="password">비밀번호</string>
+    <string name="nickname">닉네임</string>
+    <string name="birth_year">출생연도</string>
+    <string name="gender">성별</string>
+    <string name="gender_male">남자</string>
+    <string name="gender_female">여자</string>
+    <string name="password_confirm">비밀번호 확인</string>
     <string name="logo_image">로고 이미지</string>
     <string name="back">뒤로가기</string>
     <string name="register">회원가입</string>
@@ -39,9 +46,8 @@
     <string name="login_without_register">비회원으로 이용하기</string>
     <string name="login_find_id_password">아이디/비밀번호 찾기</string>
 
-    <!-- 회원가입 -->
-    <string name="register_phone_auth_title_1">본인 확인을 위해</string>
-    <string name="register_phone_auth_title_2">휴대폰 번호를 입력해주세요</string>
+    <!-- 회원가입 Step1 -->
+    <string name="register_phone_auth_title">본인 확인을 위해\n휴대폰 번호를 입력해주세요</string>
     <string name="register_phone_auth_placeholder">\'-\' 구분 없이 입력</string>
     <string name="register_phone_auth_retry_desc">재전송은 3회까지만 가능해요</string>
 
@@ -49,4 +55,24 @@
     <string name="register_phone_auth_number_hint">문자가 오지 않는다면 \'재전송' 버튼을 눌러주세요</string>
     <string name="register_phone_auth_number_error_1">인증번호를 다시 확인해주세요</string>
     <string name="register_phone_auth_number_error_2">인증번호를 재전송해주세요</string>
+
+    <!-- 회원가입 Step1 -->
+    <string name="register_id_title">아이디를\n설정해주세요</string>
+    <string name="register_id_placeholder">6~12자, 영문/숫자 조합</string>
+    <string name="register_id_duplicate_check">아이디 중복 여부를 확인해주세요</string>
+    <string name="register_id_error">6~12자, 영문/숫자 조합으로 입력해주세요</string>
+    <string name="register_id_valid">사용 가능한 아이디입니다</string>
+    <string name="register_id_invalid">이미 사용중인 아이디입니다</string>
+
+    <!-- 회원가입 Step3 -->
+    <string name="register_password_title">비밀번호를\n설정해주세요</string>
+    <string name="register_password_placeholder">8자 이상, 영문/숫자 조합</string>
+    <string name="register_password_error_length">8자 이상의 비밀번호를 입력해주세요</string>
+    <string name="register_password_error_combination">영문/숫자 조합으로 구성해주세요</string>
+
+    <!-- 회원가입 Step4 -->
+    <string name="register_nickname_title">프로필 설정을 위해\n회원정보를 입력해주세요</string>
+    <string name="register_nickname_placeholder">12자 이내, 특수문자 사용 불가</string>
+    <string name="register_birth_year_desc">출생연도는 뉴스레터 추천에 활용돼요</string>
+    <string name="register_nickname_invalid">특수문자는 사용할 수 없어요</string>
 </resources>


### PR DESCRIPTION
### 회원가입 4단계 화면 추가
- 닉네임 입력
- 닉네임 유효성 검사
- 출생연도 선택 버튼만 추가
- 성별 선택(남자/여자)

### TODO (Related to #14 )
- 출생연도 선택 버튼 클릭 시 드롭다운 vs 바텀시트 중 어떤 걸로 구현할지 기획자와 상의

