### PR TITLE
[FEAT] 회원가입 5단계 UI 구현

### DIFF
--- a/presentation/src/main/java/com/and/presentation/component/HintErrorTextField.kt
+++ b/presentation/src/main/java/com/and/presentation/component/HintErrorTextField.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.and.presentation.ui.Primary0
@@ -38,6 +39,7 @@ fun HintErrorTextField(
         Text(
             text = valueTitle,
             fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(start = 6.dp)
         )
         Spacer(modifier = Modifier.height(8.dp))

--- a/presentation/src/main/java/com/and/presentation/component/PhoneAuthRequestTextField.kt
+++ b/presentation/src/main/java/com/and/presentation/component/PhoneAuthRequestTextField.kt
@@ -48,6 +48,7 @@ fun PhoneAuthTextField(
         Text(
             text = stringResource(id = R.string.phone_number_title),
             fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
             modifier = Modifier
                 .padding(start = 8.dp)
         )

--- a/presentation/src/main/java/com/and/presentation/component/button/ConditionalNextButton.kt
+++ b/presentation/src/main/java/com/and/presentation/component/button/ConditionalNextButton.kt
@@ -19,12 +19,15 @@ import com.and.presentation.ui.Tint10
 
 /**
  * 조건에 따라 enable 여부가 변경되는 버튼
+ *
+ * @param buttonText "다음"이 아닌 다른 버튼 텍스트를 사용해야 하는 경우
  */
 @Composable
 fun ConditionalNextButton(
     enabled: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    buttonText: String = stringResource(id = R.string.next)
 ) {
     Button(
         onClick = onClick,
@@ -38,7 +41,7 @@ fun ConditionalNextButton(
         )
     ) {
         Text(
-            text = stringResource(id = R.string.next),
+            text = buttonText,
             color = if (enabled) Tint10
                 else Neutral10,
             fontSize = 16.sp,

--- a/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep2Screen.kt
+++ b/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep2Screen.kt
@@ -138,7 +138,7 @@ fun RegisterStep2Screen(
                     text = message,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Medium,
-                    modifier = Modifier.padding(top = 6.dp),
+                    modifier = Modifier.padding(top = 6.dp, start = 6.dp),
                     color = messageColor
                 )
             }

--- a/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep5Screen.kt
+++ b/presentation/src/main/java/com/and/presentation/screen/register/RegisterStep5Screen.kt
@@ -1,0 +1,235 @@
+package com.and.presentation.screen.register
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.and.presentation.R
+import com.and.presentation.component.button.ConditionalNextButton
+import com.and.presentation.ui.DefaultWhiteTheme
+import com.and.presentation.ui.Neutral1
+import com.and.presentation.ui.Primary0
+import com.and.presentation.util.removeRippleEffect
+
+@Composable
+fun RegisterStep5Screen(
+    onNext: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isTerm1Checked by remember { mutableStateOf(false) }
+    var isTerm2Checked by remember { mutableStateOf(false) }
+    var isTerm3Checked by remember { mutableStateOf(false) }
+    var isTerm4Checked by remember { mutableStateOf(false) }
+    var isAllTermsChecked = isTerm1Checked && isTerm2Checked
+            && isTerm3Checked && isTerm4Checked
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 14.dp)
+        ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = stringResource(R.string.register_terms_title),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(48.dp))
+            RegisterTermAgreeButton(
+                title = stringResource(R.string.register_terms_term_1),
+                initialChecked = isTerm1Checked,
+                onCheckChange = { isTerm1Checked = it }
+            )
+            RegisterTermAgreeButton(
+                title = stringResource(R.string.register_terms_term_2),
+                initialChecked = isTerm2Checked,
+                onCheckChange = { isTerm2Checked = it }
+            )
+            RegisterTermAgreeButton(
+                title = stringResource(R.string.register_terms_term_3),
+                initialChecked = isTerm3Checked,
+                onCheckChange = { isTerm3Checked = it }
+            )
+            RegisterTermAgreeButton(
+                title = stringResource(R.string.register_terms_term_4),
+                initialChecked = isTerm4Checked,
+                onCheckChange = { isTerm4Checked = it }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            RegisterTermAgreeAllButton(
+                initialChecked = isAllTermsChecked,
+                onCheckChange = { newState ->
+                    isTerm1Checked = newState
+                    isTerm2Checked = newState
+                    isTerm3Checked = newState
+                    isTerm4Checked = newState
+                }
+            )
+        }
+
+        ConditionalNextButton(
+            buttonText = stringResource(R.string.register_terms_complete),
+            enabled = isTerm1Checked && isTerm2Checked && isTerm3Checked,
+            onClick = onNext,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Composable
+fun RegisterTermAgreeButton(
+    title: String,
+    initialChecked: Boolean,
+    modifier: Modifier = Modifier,
+    onCheckChange: (Boolean) -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .removeRippleEffect {
+                onCheckChange(!initialChecked)
+            }
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(Color.White)
+            .padding(start = 8.dp, end = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                color = Color.Gray,
+                modifier = Modifier.weight(1f)
+            )
+            Box(
+                modifier = Modifier
+                    .size(18.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(
+                        if (initialChecked) Primary0 else Color.White
+                    )
+                    .border(
+                        width = if (initialChecked) 0.dp else 1.dp,
+                        shape = RoundedCornerShape(5.dp),
+                        color = Color.Gray
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_checkmark),
+                    contentDescription = null,
+                    tint = if (initialChecked) Color.White else Color.Gray
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RegisterTermAgreeAllButton(
+    initialChecked: Boolean,
+    modifier: Modifier = Modifier,
+    onCheckChange: (Boolean) -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(58.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Neutral1)
+            .clickable {
+                onCheckChange(!initialChecked)
+            }
+            .padding(start = 8.dp, end = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.register_terms_term_all),
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.Gray,
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp)
+                    .weight(1f)
+            )
+            Box(
+                modifier = Modifier
+                    .size(18.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(
+                        if (initialChecked) Primary0 else Color.White
+                    )
+                    .border(
+                        width = if (initialChecked) 0.dp else 1.dp,
+                        shape = RoundedCornerShape(5.dp),
+                        color = Color.Gray
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_checkmark),
+                    contentDescription = null,
+                    tint = if (initialChecked) Color.White else Color.Gray
+                )
+            }
+        }
+    }
+}
+
+@Preview(
+    name = "RegisterStep5Screen Preview",
+    showBackground = true
+)
+@Composable
+fun RegisterStep5ScreenPreview() {
+    DefaultWhiteTheme {
+        RegisterStep5Screen(
+            onNext = {
+
+            },
+            onBack = {
+
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/and/presentation/util/StringExtensions.kt
+++ b/presentation/src/main/java/com/and/presentation/util/StringExtensions.kt
@@ -10,7 +10,7 @@ package com.and.presentation.util
  *
  * @author 로키
  * @throws IllegalArgumentException 문자열 길이가 3 이하일 경우 예외가 발생합니다.
- * @receiver [com.and.presentation.model.RegisteredUser]의 [id]
+ * @receiver [com.and.presentation.model.RegisteredUser]의 id 값
  * @return 끝 3글자가 마스킹 처리된 문자열
  */
 fun String.toMaskedString(): String {
@@ -19,4 +19,42 @@ fun String.toMaskedString(): String {
     } else {
         this.substring(0, this.length - 3) + "***"
     }
+}
+
+/**
+ * 사용자의 비밀번호가
+ * (1) 영문/숫자를 모두 포함하고
+ * (2) 다른 문자는 포함하지 않는지 체크합니다.
+ *
+ * 예시:
+ * ```
+ * "abcdabcd" -> false
+ * "abcd1234" -> true
+ * ```
+ *
+ * @author 로키
+ * @receiver [String]
+ * @return 조건 만족 여부
+ */
+fun String.passwordValidation(): Boolean {
+    val passwordRegex = Regex("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9]{6,12}$")
+    return passwordRegex.matches(this)
+}
+
+/**
+ * 사용자의 닉네임이
+ * (1) 특수문자를 포함하지 않음
+ * 위 조건을 만족하는지 체크합니다.
+ *
+ * 예시:
+ * ```
+ * "로키*23$" -> false
+ * ```
+ *
+ * @author 로키
+ * @receiver [String]
+ * @return 조건 만족 여부
+ */
+fun String.nicknameValidation(): Boolean {
+    return this.all { it.isLetterOrDigit() }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -75,4 +75,13 @@
     <string name="register_nickname_placeholder">12자 이내, 특수문자 사용 불가</string>
     <string name="register_birth_year_desc">출생연도는 뉴스레터 추천에 활용돼요</string>
     <string name="register_nickname_invalid">특수문자는 사용할 수 없어요</string>
+
+    <!-- 회원가입 Step5 -->
+    <string name="register_terms_title">마지막으로\n이용 약관에 동의해주세요</string>
+    <string name="register_terms_term_1">만 14세 이상 확인 (필수)</string>
+    <string name="register_terms_term_2">서비스 이용 동의 (필수)</string>
+    <string name="register_terms_term_3">개인정보 수집 및 이용 동의 (필수)</string>
+    <string name="register_terms_term_4">마케팅 활용/광고성 정보 수신 동의 (선택)</string>
+    <string name="register_terms_term_all">전체 약관 동의</string>
+    <string name="register_terms_complete">가입 완료</string>
 </resources>


### PR DESCRIPTION
### 회원가입 5단계 화면 추가
- 약관 동의 영역 4개(필수3, 선택1)
- 전체 동의 영역 1개
- 필수 약관 3개가 모두 동의된 상태 + @일 때 "가입 완료"버튼이 활성화

### TODO (Related to #16 )
- 약관 클릭 시 바텀시트(WebView를 포함한)에서 약관 페이지 보여주기