### PR TITLE
Implement getSearchedNewsLetter API integration

### DIFF
--- a/data/src/main/java/com/and/data/api/newsletter/GetSearchedNewsLettersApi.kt
+++ b/data/src/main/java/com/and/data/api/newsletter/GetSearchedNewsLettersApi.kt
@@ -1,14 +1,13 @@
 package com.and.data.api.newsletter
 
-import retrofit2.Response
+import com.and.data.model.response.GetNewsLettersResponseDto.NewsLetterDetailDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface GetSearchedNewsLettersApi {
 
-    // TODO 응답 객체 작성
     @GET("/newsletters/search")
     suspend fun getSearchedNewsLetters(
         @Query("brandName") brandName: String
-    ): Response<Unit>
+    ): NewsLetterDetailDto
 }

--- a/data/src/main/java/com/and/data/repository/MemberNewsLetterRepositoryImpl.kt
+++ b/data/src/main/java/com/and/data/repository/MemberNewsLetterRepositoryImpl.kt
@@ -114,7 +114,14 @@ class MemberNewsLetterRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSearchedNewsLetter(brandName: String): NewsLetter {
-        TODO("Not yet implemented")
+        return handleApiCall(
+            apiCall = {
+                getSearchedNewsLettersApi.getSearchedNewsLetters(brandName)
+            },
+            mapper = { response ->
+                newsLetterDetailMapper.mapToDomain(response)
+            }
+        )
     }
 
     override suspend fun getSubscribedNewsLetters(): List<BriefNewsLetter> {


### PR DESCRIPTION
## Feature PR Template

### 변경 전
- `GetSearchedNewsLettersApi`의 응답 타입이 `Response<Unit>`으로 정의되어 있었음
- TODO 주석으로 응답 객체 작성이 필요한 상태
- `MemberNewsLetterRepositoryImpl`의 `getSearchedNewsLetter` 메서드가 미구현 상태 (TODO)

### 변경 후
- `GetSearchedNewsLettersApi`의 응답 타입을 `NewsLetterDetailDto`로 변경
- 불필요한 `Response` 래퍼 제거
- `MemberNewsLetterRepositoryImpl`의 `getSearchedNewsLetter` 메서드 구현
  - `handleApiCall`을 통한 API 호출 처리
  - `newsLetterDetailMapper`를 사용하여 DTO를 Domain 모델로 변환

### 관련 이슈
뉴스레터 검색 기능 구현

### 테스트 방법
1. 브랜드명으로 뉴스레터 검색 API 호출
2. 반환된 `NewsLetter` 객체가 올바르게 매핑되었는지 확인
3. API 에러 발생 시 `handleApiCall`의 에러 처리 로직이 정상 작동하는지 확인

### 기타 참고 사항
- `handleApiCall` 유틸리티 함수를 활용하여 일관된 에러 처리 적용
- 기존 다른 API 호출 메서드들과 동일한 패턴으로 구현

https://claude.ai/code/session_01Nj5GnNy5betF6XGitf7B4m